### PR TITLE
Added a setup method that can be called on a UIViewController that doesn't conform to AutoCompleteDelegate

### DIFF
--- a/Autocomplete/AutoComplete/Autocomplete.swift
+++ b/Autocomplete/AutoComplete/Autocomplete.swift
@@ -9,21 +9,38 @@
 import UIKit
 public class Autocomplete {
     public class func setupAutocompleteForViewcontroller<T: UIViewController where T: AutocompleteDelegate>(viewController: T) {
-
-        let podBundle: NSBundle = NSBundle(forClass: Autocomplete.self)
-
-        let storyboard = UIStoryboard(name: "Autocomplete", bundle: podBundle)
-        let autoCompleteViewController = storyboard.instantiateViewControllerWithIdentifier("autocompleteScene") as! AutoCompleteViewController
-        
+        let autoCompleteViewController = initAutoCompleteVC()
         autoCompleteViewController.delegate = viewController
 
-        autoCompleteViewController.willMoveToParentViewController(viewController)
-        viewController.addChildViewController(autoCompleteViewController)
-        autoCompleteViewController.didMoveToParentViewController(viewController)
+        setupUI(autoCompleteViewController, parentViewController: viewController)
 
-        autoCompleteViewController.view.willMoveToSuperview(viewController.view)
-        viewController.view.addSubview(autoCompleteViewController.view)
+    }
+    public class func setupAutocompleteForViewcontrollerWithDetachedDelegate(viewController: UIViewController, delegate:AutocompleteDelegate) {
+        let autoCompleteViewController = initAutoCompleteVC()
+        autoCompleteViewController.delegate = delegate
+        
+        setupUI(autoCompleteViewController, parentViewController: viewController)
+        
+    }
+    
+    private class func initAutoCompleteVC() -> AutoCompleteViewController {
+        let podBundle: NSBundle = NSBundle(forClass: Autocomplete.self)
+        
+        let storyboard = UIStoryboard(name: "Autocomplete", bundle: podBundle)
+        return storyboard.instantiateViewControllerWithIdentifier("autocompleteScene") as! AutoCompleteViewController
+    }
+    
+    private class func setupUI(autoCompleteViewController: AutoCompleteViewController, parentViewController: UIViewController) {
+        //Remove from any superview and super viewcontrollers
+        autoCompleteViewController.view.removeFromSuperview()
+        autoCompleteViewController.removeFromParentViewController()
+        
+        autoCompleteViewController.willMoveToParentViewController(parentViewController)
+        parentViewController.addChildViewController(autoCompleteViewController)
+        autoCompleteViewController.didMoveToParentViewController(parentViewController)
+        
+        autoCompleteViewController.view.willMoveToSuperview(parentViewController.view)
+        parentViewController.view.addSubview(autoCompleteViewController.view)
         autoCompleteViewController.view.didMoveToSuperview()
-
     }
 }


### PR DESCRIPTION
I added an additional setup method that can be called on a UIViewController that doesn't conform to AutoCompleteDelegate. The delegate must be provided manually, but this allows for skinny view controllers, view models, etc where conforming to AutoCompleteDelegate might get messy.
